### PR TITLE
Add experimental same-size SD clone with FAT32 auto-shrink.

### DIFF
--- a/core/partition_scanner.py
+++ b/core/partition_scanner.py
@@ -375,11 +375,6 @@ class PartitionScanner:
             target_layout.android_dynamic = source_layout.android_dynamic
             logger.info(f"Will migrate Android: {source_layout.android_size_mb} MB")
 
-        # Set has_gpt based on whether we're migrating Android
-        # GPT is only needed when Android partitions exist (too many to fit in MBR)
-        target_layout.has_gpt = (source_layout.has_android and options['migrate_android'])
-        logger.info(f"Target will use {'hybrid MBR+GPT' if target_layout.has_gpt else 'pure MBR'} partition table")
-
         # emuMMC (fixed size if migrating)
         if source_layout.has_emummc and options['migrate_emummc']:
             total_reserved_mb += source_layout.emummc_size_mb
@@ -388,7 +383,11 @@ class PartitionScanner:
         else:
             logger.warning(f"NOT migrating emuMMC - has_emummc={source_layout.has_emummc}, migrate_emummc={options.get('migrate_emummc', 'NOT SET')}")
 
-        # FAT32 - expand if requested
+        # FAT32 - expand if requested, or shrink to fit for same-size clone
+        has_gpt = (source_layout.has_android and options['migrate_android'])
+        logger.info(f"Target will use {'hybrid MBR+GPT' if has_gpt else 'pure MBR'} partition table")
+
+        fat32_sectors = None
         if options['expand_fat32']:
             # Calculate available space
             total_disk_mb = (target_layout.total_sectors * SECTOR_SIZE) // (1024 * 1024)
@@ -400,7 +399,7 @@ class PartitionScanner:
             # - GPT backup structures (33 sectors for entries + 1 sector for header)
             # - Windows sector access quirks near disk boundaries
             # - Safety margin to prevent "sector not found" errors
-            if target_layout.has_gpt:
+            if has_gpt:
                 # GPT: Reserve for backup structures + alignment + safety
                 end_reserve_mb = 20
             else:
@@ -409,12 +408,25 @@ class PartitionScanner:
 
             reserved_mb = total_reserved_mb + start_alignment_mb + end_reserve_mb
             fat32_size_mb = total_disk_mb - reserved_mb
+        elif options.get('shrink_fat32_to_fit'):
+            fat32_sectors = self._shrink_fat32_for_clone(
+                source_layout,
+                target_layout.total_sectors,
+                has_gpt,
+                options
+            )
+            fat32_size_mb = (fat32_sectors * SECTOR_SIZE) // (1024 * 1024)
         else:
             fat32_size_mb = source_layout.fat32_size_mb
 
+        # Set has_gpt based on whether we're migrating Android
+        # GPT is only needed when Android partitions exist (too many to fit in MBR)
+        target_layout.has_gpt = has_gpt
+
         # Create partition objects (in order)
         # 1. FAT32
-        fat32_sectors = (fat32_size_mb * 1024 * 1024) // SECTOR_SIZE
+        if fat32_sectors is None:
+            fat32_sectors = (fat32_size_mb * 1024 * 1024) // SECTOR_SIZE
         fat32_part = Partition(
             name='hos_data',
             type_id=0x0C,
@@ -523,3 +535,64 @@ class PartitionScanner:
                 )
 
         return target_layout
+
+    def _compute_layout_end_sector(self, source_layout: DiskLayout, has_gpt: bool,
+                                   options: Dict, fat32_sectors: int) -> int:
+        """Calculate the end sector of the last partition for a given FAT32 size."""
+        current_lba = ALIGN_SECTORS + fat32_sectors
+
+        if current_lba % ALIGN_SECTORS != 0:
+            current_lba = ((current_lba + ALIGN_SECTORS - 1) // ALIGN_SECTORS) * ALIGN_SECTORS
+
+        if source_layout.has_linux and options['migrate_linux']:
+            linux_sectors = (source_layout.linux_size_mb * 1024 * 1024) // SECTOR_SIZE
+            current_lba += linux_sectors
+            if current_lba % ALIGN_SECTORS != 0:
+                current_lba = ((current_lba + ALIGN_SECTORS - 1) // ALIGN_SECTORS) * ALIGN_SECTORS
+
+        if source_layout.has_android and options['migrate_android']:
+            for apart in source_layout.get_android_partitions():
+                current_lba += apart.size_sectors
+            if current_lba % ALIGN_SECTORS != 0:
+                current_lba = ((current_lba + ALIGN_SECTORS - 1) // ALIGN_SECTORS) * ALIGN_SECTORS
+
+        if source_layout.has_emummc and options['migrate_emummc']:
+            safety_margin = 2048  # 1MB
+            for epart in source_layout.get_emummc_partitions():
+                current_lba += max(0, epart.size_sectors - safety_margin)
+
+        return current_lba
+
+    def _shrink_fat32_for_clone(self, source_layout: DiskLayout, target_total_sectors: int,
+                                has_gpt: bool, options: Dict) -> int:
+        """
+        Shrink FAT32 to fit fixed trailing partitions on a slightly smaller same-size SD card.
+        Returns FAT32 size in sectors.
+        """
+        import logging
+        logger = logging.getLogger(__name__)
+
+        source_fat32_sectors = (source_layout.fat32_size_mb * 1024 * 1024) // SECTOR_SIZE
+        fat32_sectors = source_fat32_sectors
+        min_fat32_sectors = ALIGN_SECTORS  # 16 MB minimum
+
+        while fat32_sectors >= min_fat32_sectors:
+            end_sector = self._compute_layout_end_sector(
+                source_layout, has_gpt, options, fat32_sectors
+            )
+            if end_sector <= target_total_sectors:
+                if fat32_sectors < source_fat32_sectors:
+                    reduced_mb = ((source_fat32_sectors - fat32_sectors) * SECTOR_SIZE) / (1024 * 1024)
+                    logger.warning(
+                        f"Shrunk FAT32 by {reduced_mb:.1f} MB to fit same-size target SD card"
+                    )
+                return fat32_sectors
+
+            overflow_sectors = end_sector - target_total_sectors
+            fat32_sectors -= max(overflow_sectors, 2048)
+
+        raise ValueError(
+            "Fixed partitions (Linux, Android, emuMMC) exceed target disk capacity.\n\n"
+            "The target SD card is too small to hold all non-FAT32 partitions.\n"
+            "Please use a larger capacity SD card."
+        )

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -73,6 +73,7 @@ class MainWindow:
 
         # Settings
         self.temp_backup_dir = None  # None = use system default (temp folder)
+        self.allow_same_size_clone = False  # Experimental: allow same-capacity-tier cloning
         self._load_settings()
 
         # Build UI
@@ -95,6 +96,8 @@ class MainWindow:
         settings_menu = ttk.Menu(menubar, tearoff=0)
         menubar.add_cascade(label="Settings", menu=settings_menu)
         settings_menu.add_command(label="Temp Backup Directory", command=self._show_backup_dir_settings)
+        settings_menu.add_separator()
+        settings_menu.add_command(label="Experimental...", command=self._show_experimental_settings)
 
         # Help Menu
         help_menu = ttk.Menu(menubar, tearoff=0)
@@ -396,14 +399,27 @@ class MainWindow:
             source_tier = get_sd_tier(self.source_disk['size_gb'])
             target_tier = get_sd_tier(disk_info['size_gb'])
 
-            # Target must be same tier or larger
+            # Target must be larger, or same tier when experimental clone mode is enabled
             if target_tier < source_tier:
                 self.show_custom_info(
                     "Invalid Target",
                     f"Target disk ({disk_info['letter']}, {disk_info['size_gb']:.1f} GB) is smaller than source disk ({self.source_disk['letter']}, {self.source_disk['size_gb']:.1f} GB).\n\n"
-                    f"Target must be same capacity tier ({source_tier} GB) or larger.",
+                    f"Target must be a larger capacity SD card.",
                     width=500,
                     height=220
+                )
+                self.disk_selector.clear_target()
+                self.target_disk = None
+                return
+
+            if target_tier == source_tier and not self.allow_same_size_clone:
+                self.show_custom_info(
+                    "Same-Size SD Not Allowed",
+                    f"Target disk ({disk_info['letter']}, {disk_info['size_gb']:.1f} GB) is the same capacity tier as the source ({source_tier} GB).\n\n"
+                    f"By default, migration requires a larger SD card.\n\n"
+                    f"To clone to a same-size SD card, enable the experimental setting under Settings > Experimental.",
+                    width=520,
+                    height=260
                 )
                 self.disk_selector.clear_target()
                 self.target_disk = None
@@ -566,12 +582,15 @@ class MainWindow:
                 # Check if Clone Mode (same capacity tier)
                 source_tier = get_sd_tier(self.source_disk['size_gb'])
                 target_tier = get_sd_tier(self.target_disk['size_gb'])
-                is_clone_mode = (source_tier == target_tier)
+                is_clone_mode = (
+                    self.allow_same_size_clone and source_tier == target_tier
+                )
 
-                # In Clone Mode, override expand_fat32 to False
+                # In Clone Mode, override expand_fat32 to False and shrink FAT32 if needed
                 options_for_calc = self.migration_options.copy()
                 if is_clone_mode:
                     options_for_calc['expand_fat32'] = False
+                    options_for_calc['shrink_fat32_to_fit'] = True
 
                 # Migration mode: calculate layout for target disk
                 new_layout = self.scanner.calculate_target_layout(
@@ -1510,6 +1529,7 @@ Made for the Nintendo Switch homebrew community
                 with open('.nx_migrator_prefs.json', 'r') as f:
                     prefs = json.load(f)
                     self.temp_backup_dir = prefs.get('temp_backup_dir', None)
+                    self.allow_same_size_clone = prefs.get('allow_same_size_clone', False)
         except Exception:
             pass
 
@@ -1524,6 +1544,7 @@ Made for the Nintendo Switch homebrew community
 
             # Update with current settings
             prefs['temp_backup_dir'] = self.temp_backup_dir
+            prefs['allow_same_size_clone'] = self.allow_same_size_clone
 
             with open('.nx_migrator_prefs.json', 'w') as f:
                 json.dump(prefs, f)
@@ -1619,6 +1640,95 @@ Made for the Nintendo Switch homebrew community
         ).pack(side=LEFT, padx=5)
 
         # Center dialog
+        dialog.update_idletasks()
+        parent_x = self.root.winfo_x()
+        parent_y = self.root.winfo_y()
+        parent_w = self.root.winfo_width()
+        parent_h = self.root.winfo_height()
+        x = parent_x + (parent_w // 2) - (width // 2)
+        y = parent_y + (parent_h // 2) - (height // 2)
+        dialog.geometry(f"{width}x{height}+{x}+{y}")
+        dialog.deiconify()
+        dialog.lift()
+        dialog.attributes('-topmost', True)
+        dialog.after(100, lambda: dialog.attributes('-topmost', False))
+        dialog.focus_force()
+
+    def _show_experimental_settings(self):
+        """Show dialog for experimental settings"""
+        dialog = ttk.Toplevel(self.root)
+        dialog.title("Experimental Settings")
+        dialog.transient(self.root)
+        dialog.withdraw()
+        dialog.grab_set()
+
+        width = 620
+        height = 320
+
+        main_frame = ttk.Frame(dialog, padding=20)
+        main_frame.pack(fill=BOTH, expand=True)
+
+        ttk.Label(
+            main_frame,
+            text="Experimental Settings",
+            font=("Segoe UI", 12, "bold")
+        ).pack(pady=(0, 10))
+
+        ttk.Label(
+            main_frame,
+            text="These features are experimental and may fail in edge cases.\nUse at your own risk.",
+            justify=CENTER,
+            bootstyle=WARNING
+        ).pack(pady=(0, 15))
+
+        clone_var = ttk.BooleanVar(value=self.allow_same_size_clone)
+        clone_check = ttk.Checkbutton(
+            main_frame,
+            text="Allow cloning to same-size SD card",
+            variable=clone_var,
+            bootstyle="warning-round-toggle"
+        )
+        clone_check.pack(anchor=W, pady=(0, 10))
+
+        ttk.Label(
+            main_frame,
+            text=(
+                "Enables Clone Mode when the target SD card is the same capacity tier\n"
+                "as the source (e.g. 128 GB to 128 GB). Partitions are copied without\n"
+                "FAT32 expansion. If the target card is slightly smaller, the FAT32\n"
+                "partition is automatically shrunk to fit."
+            ),
+            justify=LEFT,
+            font=("Segoe UI", 9),
+            wraplength=560
+        ).pack(anchor=W, pady=(0, 15))
+
+        button_frame = ttk.Frame(main_frame)
+        button_frame.pack(pady=(10, 0))
+
+        def save_and_close():
+            self.allow_same_size_clone = clone_var.get()
+            self._save_settings()
+            status = "enabled" if self.allow_same_size_clone else "disabled"
+            self._update_status(f"Experimental same-size SD clone: {status}")
+            dialog.destroy()
+
+        ttk.Button(
+            button_frame,
+            text="Save",
+            command=save_and_close,
+            bootstyle="primary",
+            width=12
+        ).pack(side=LEFT, padx=5)
+
+        ttk.Button(
+            button_frame,
+            text="Cancel",
+            command=dialog.destroy,
+            bootstyle="secondary",
+            width=12
+        ).pack(side=LEFT, padx=5)
+
         dialog.update_idletasks()
         parent_x = self.root.winfo_x()
         parent_y = self.root.winfo_y()

--- a/package.ps1
+++ b/package.ps1
@@ -1,0 +1,98 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Build a distributable zip for NX Migrator Pro.
+
+.DESCRIPTION
+    Creates a zip archive containing core/, gui/, tool/, install.bat, and main.py.
+
+.PARAMETER OutputZip
+    Path for the output zip file. Defaults to dist/NXMigratorPro-X.X.X.zip,
+    where the version comes from the latest git tag.
+
+.EXAMPLE
+    .\package.ps1
+
+.EXAMPLE
+    .\package.ps1 -OutputZip "C:\releases\NXMigratorPro-1.0.5.zip"
+#>
+param(
+    [string]$OutputZip
+)
+
+$ErrorActionPreference = "Stop"
+
+$Root = $PSScriptRoot
+
+function Get-LatestGitTagVersion {
+    $tag = git -C $Root tag --sort=-v:refname 2>$null | Select-Object -First 1
+    if (-not $tag) {
+        throw "No git tags found. Create a tag (e.g. git tag 1.0.5) before packaging."
+    }
+
+    return ($tag.Trim() -replace '^v', '')
+}
+
+if (-not $OutputZip) {
+    $version = Get-LatestGitTagVersion
+    $OutputZip = Join-Path $Root "dist\NXMigratorPro-$version.zip"
+}
+$Include = @("core", "gui", "tool", "install.bat", "main.py")
+
+foreach ($item in $Include) {
+    $path = Join-Path $Root $item
+    if (-not (Test-Path $path)) {
+        throw "Required path not found: $path"
+    }
+}
+
+$outputDir = Split-Path -Parent $OutputZip
+if ($outputDir -and -not (Test-Path $outputDir)) {
+    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+}
+
+if (Test-Path $OutputZip) {
+    Remove-Item $OutputZip -Force
+}
+
+Add-Type -AssemblyName System.IO.Compression
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$zip = [System.IO.Compression.ZipFile]::Open(
+    $OutputZip,
+    [System.IO.Compression.ZipArchiveMode]::Create
+)
+
+try {
+    foreach ($item in $Include) {
+        $fullPath = Join-Path $Root $item
+
+        if (Test-Path $fullPath -PathType Container) {
+            Get-ChildItem -Path $fullPath -Recurse -File |
+                Where-Object {
+                    $_.FullName -notmatch "\\__pycache__\\" -and
+                    $_.Extension -ne ".pyc"
+                } |
+                ForEach-Object {
+                    $entryName = $_.FullName.Substring($Root.Length + 1).Replace("\", "/")
+                    [void][System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
+                        $zip,
+                        $_.FullName,
+                        $entryName
+                    )
+                }
+        }
+        else {
+            [void][System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
+                $zip,
+                $fullPath,
+                $item
+            )
+        }
+    }
+}
+finally {
+    $zip.Dispose()
+}
+
+Write-Host "Created $OutputZip"


### PR DESCRIPTION
### Summary

Adds an opt-in experimental setting that allows migrating/cloning to a same-capacity-tier SD card (e.g. 128 GB → 128 GB). When enabled, the tool uses **Clone Mode** instead of requiring a larger target card, and automatically shrinks the FAT32 partition if the target reports slightly less usable space than the source.

This addresses a common real-world issue where two cards of the same advertised capacity are not byte-identical in size, which previously caused layout calculation to fail with errors like:

> Partitions exceed target disk capacity by 4.5 MB.

### Changes

#### GUI (`gui/main_window.py`)
- Added **Settings → Experimental...** dialog
- New setting: **Allow cloning to same-size SD card** (off by default)
- Persists preference in `.nx_migrator_prefs.json` as `allow_same_size_clone`
- Blocks same-capacity-tier target selection unless the experimental setting is enabled
- When clone mode is active:
  - Disables FAT32 expansion
  - Enables FAT32 shrink-to-fit logic during layout calculation

#### Core (`core/partition_scanner.py`)
- Added `_compute_layout_end_sector()` to calculate trailing partition usage
- Added `_shrink_fat32_for_clone()` to reduce FAT32 size until the layout fits the target disk
- New option flag: `shrink_fat32_to_fit`
- Linux, Android, and emuMMC partitions remain unchanged; only FAT32 is adjusted

### Behavior

| Scenario | Result |
|---|---|
| Experimental setting **off** | Same-tier targets are rejected; larger targets work as before |
| Experimental setting **on**, same tier, target fits | Clone Mode: partitions copied without FAT32 expansion |
| Experimental setting **on**, same tier, target slightly smaller | FAT32 is shrunk to fit; other partitions preserved |
| FAT32 data exceeds shrunk partition | Layout may succeed, but file copy may still fail |

### Notes / risks

- Marked **experimental** because same-size cloning depends on card-reported capacities and available FAT32 free space
- FAT32 shrink only applies when experimental clone mode is active
- Users with nearly full FAT32 partitions may still fail during file copy even if layout calculation succeeds

### Screenshots

<img width="1551" height="957" alt="Xnapper-2026-07-07-23 19 32" src="https://github.com/user-attachments/assets/7756f4c1-e575-4632-bf82-db39fd935339" />
<img width="1569" height="955" alt="Xnapper-2026-07-07-23 19 43" src="https://github.com/user-attachments/assets/a149c979-797a-472d-8f76-55c7b1efddd0" />
<img width="1567" height="964" alt="Xnapper-2026-07-07-23 19 59" src="https://github.com/user-attachments/as
<img width="1060" height="709" alt="Xnapper-2026-07-07-23 22 01" src="https://github.com/user-attachments/assets/8d1e625d-b66f-4b3b-b11f-03fceba287c3" />
sets/ded27d7b-cc48-4f87-aba5-d3500cf1fdf5" />
